### PR TITLE
Fix package.json to work with Windows in addition to Linux, bump version...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "uvrun",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Tim Caswell <tim@creationix.com>",
-  "main": "build/Release/obj.target/uvrun.node",
+  "main": "build/Release/uvrun.node",
   "repository": { 
     "type": "git",
     "url": "http://github.com/creationix/uvrun"


### PR DESCRIPTION
The pre-patch package.json in v0.1.1 works fine on Linux (node v0.8.12), though on Windows (node v0.10.22) it doesn't work.  The issue seems to be including "obj.target" in the path to the compiled module isn't portable.  On Linux the compiled uvrun.node file exists in both build/Release and in build/Release/obj.target, though on Windows it exists only in build/Release.  Based on my (very casual) read of [an example](http://nodejs.org/api/all.html#all_hello_world) it seems the path should not include "obj.target".  I can confirm that with the proposed change it works on both Windows and Linux.  Please consider incorporating this change, thanks!
